### PR TITLE
Fix AddPeer device error handling

### DIFF
--- a/internal/server/grpc_service.go
+++ b/internal/server/grpc_service.go
@@ -66,6 +66,7 @@ func (a *agentService) AddPeer(ctx context.Context, req *proto.AddPeerRequest) (
 	device, err := a.wgClient.Device(iface)
 	if err != nil {
 		a.log.Error("failed to get device after add", "error", err)
+		return nil, err
 	}
 
 	return &proto.AddPeerResponse{ListenPort: int32(device.ListenPort)}, nil

--- a/internal/server/grpc_service_test.go
+++ b/internal/server/grpc_service_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	proto "github.com/our-org/wg-project/api"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"log/slog"
+)
+
+// errClient is a wireguard.Client that returns an error from Device
+// but succeeds for ConfigureDevice.
+type errClient struct{}
+
+func (errClient) Device(name string) (*wgtypes.Device, error) {
+	return nil, io.EOF
+}
+
+func (errClient) ConfigureDevice(name string, cfg wgtypes.Config) error {
+	return nil
+}
+
+func (errClient) Close() error { return nil }
+
+func TestAddPeer_DeviceError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := newAgentService(logger, errClient{}, "wg0")
+
+	_, err := svc.AddPeer(context.Background(), &proto.AddPeerRequest{
+		PublicKey:  "jNQKmw+IF/llmxOlGwrMxaHiPiG5xQyBq3/OmfEpuQM=",
+		AllowedIp:  "10.8.0.10/32",
+		KeepaliveS: 0,
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- fix panic potential in AddPeer when Device fails
- add regression test for AddPeer device error

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841bea4423883309fab269b4358c91f